### PR TITLE
Solution for #2

### DIFF
--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="xunit.runner.console" version="2.1.0" />
+</packages>

--- a/src/EF.Interception.Net45/EntityEntry.cs
+++ b/src/EF.Interception.Net45/EntityEntry.cs
@@ -8,9 +8,12 @@ namespace EF.Interception
     {
         private readonly DbEntityEntry _entry;
 
-        public EntityEntry(DbEntityEntry entry)
+        private EntityState _beforeState;
+
+        public EntityEntry(DbEntityEntry entry, EntityState beforeState)
         {
             _entry = entry;
+            _beforeState = beforeState;
         }
 
         public object Entity
@@ -22,6 +25,11 @@ namespace EF.Interception
         {
             get { return _entry.State; }
             set { _entry.State = value; }
+        }
+
+        public EntityState BeforeState
+        {
+            get { return _beforeState; }
         }
 
         public DbEntityValidationResult ValidationResult

--- a/src/EF.Interception.Net45/IEntityEntry.cs
+++ b/src/EF.Interception.Net45/IEntityEntry.cs
@@ -21,6 +21,11 @@ namespace EF.Interception
         EntityState State { get; set; }
 
         /// <summary>
+        /// Gets the entity's state before saving changes in context.
+        /// </summary>
+        EntityState BeforeState { get; }
+
+        /// <summary>
         /// Gets the entity's validation result.
         /// </summary>
         /// <value>The entity's validation result.</value>

--- a/src/EF.Interception.Net45/InterceptionDbContext.cs
+++ b/src/EF.Interception.Net45/InterceptionDbContext.cs
@@ -46,7 +46,7 @@ namespace EF.Interception
         {
             var modifiedEntries = ChangeTracker.Entries()
                 .Where(IsChanged)
-                .Select(entry => new EntityEntry(entry))
+                .Select(entry => new EntityEntry(entry, entry.State))
                 .ToList();
 
             Intercept(modifiedEntries, false);

--- a/src/EF.Interception.Net45/Interceptor.cs
+++ b/src/EF.Interception.Net45/Interceptor.cs
@@ -66,7 +66,7 @@ namespace EF.Interception
 
             if (!(entityEntry.Entity is TEntity)) return;
 
-            foreach (var method in _methods.Where(m => m.CanIntercept(entityEntry.State, isPostSave)))
+            foreach (var method in _methods.Where(m => m.CanIntercept(entityEntry.BeforeState, isPostSave)))
             {
                 method.Invoke(this, entityEntry);
             }

--- a/test/EF.Interception.Tests/EF.Interception.Tests.csproj
+++ b/test/EF.Interception.Tests/EF.Interception.Tests.csproj
@@ -58,6 +58,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="TestObjects\IPostExecutedEntity.cs" />
     <Compile Include="TestObjects\MockInterceptor.cs" />
     <Compile Include="TestObjects\Book.cs" />
     <Compile Include="TestObjects\IEntity.cs" />
@@ -68,6 +69,7 @@
     <Compile Include="TestObjects\AuditInterceptor.cs" />
     <Compile Include="TestObjects\IAuditedEntity.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestObjects\PostExecuteInterceptor.cs" />
     <Compile Include="TestObjects\SoftDeleteInterceptor.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/test/EF.Interception.Tests/InterceptionDbContextTests.cs
+++ b/test/EF.Interception.Tests/InterceptionDbContextTests.cs
@@ -57,6 +57,24 @@ namespace EF.Interception.Tests
                 Assert.True(book.IsDeleted);
             }
 
+            [Fact]
+            public void ShouldExecutePostMethodWhenEntityIsAdded()
+            {
+                _context.AddInterceptor(new PostExecuteInterceptor());
+
+                var book = new Book
+                {
+                    Name = "Harry Potter and the Globet of Fire",
+                    CreatedAt = DateTime.Now, // Need these for validation...
+                    ModifiedAt = DateTime.Now
+                };
+
+                _context.Books.Add(book);
+                _context.SaveChanges();
+
+                Assert.True(book.IsPostExecuted);
+            }
+
             public void Dispose()
             {
                 _context.Dispose();

--- a/test/EF.Interception.Tests/InterceptionDbContextTests.cs
+++ b/test/EF.Interception.Tests/InterceptionDbContextTests.cs
@@ -64,7 +64,7 @@ namespace EF.Interception.Tests
 
                 var book = new Book
                 {
-                    Name = "Harry Potter and the Globet of Fire",
+                    Name = "Harry Potter and the Goblet of Fire",
                     CreatedAt = DateTime.Now, // Need these for validation...
                     ModifiedAt = DateTime.Now
                 };

--- a/test/EF.Interception.Tests/InterceptorTests.cs
+++ b/test/EF.Interception.Tests/InterceptorTests.cs
@@ -75,6 +75,7 @@ namespace EF.Interception.Tests
                 var entityEntry = new Mock<IEntityEntry>();
                 entityEntry.SetupGet(x => x.Entity).Returns(new Book { Id = 123 });
                 entityEntry.SetupGet(x => x.State).Returns(state);
+                entityEntry.SetupGet(x => x.BeforeState).Returns(state);
 
                 var interceptor = new Mock<IInterceptor<IAuditedEntity>>(MockBehavior.Strict);
                 if (expression != null) interceptor.Setup(expression);

--- a/test/EF.Interception.Tests/TestObjects/Book.cs
+++ b/test/EF.Interception.Tests/TestObjects/Book.cs
@@ -3,7 +3,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace EF.Interception.Tests
 {
-    public class Book : IAuditedEntity, ISoftDeletedEntity
+    public class Book : IAuditedEntity, ISoftDeletedEntity, IPostExecutedEntity
     {
         public int Id { get; set; }
 
@@ -17,5 +17,7 @@ namespace EF.Interception.Tests
         public DateTime? ModifiedAt { get; set; }
 
         public bool IsDeleted { get; set; }
+
+        public bool IsPostExecuted { get; set; }
     }
 }

--- a/test/EF.Interception.Tests/TestObjects/IPostExecutedEntity.cs
+++ b/test/EF.Interception.Tests/TestObjects/IPostExecutedEntity.cs
@@ -1,0 +1,7 @@
+﻿namespace EF.Interception.Tests
+{
+    public interface IPostExecutedEntity : IEntity
+    {
+        bool IsPostExecuted { get; set; }
+    }
+}

--- a/test/EF.Interception.Tests/TestObjects/PostExecuteInterceptor.cs
+++ b/test/EF.Interception.Tests/TestObjects/PostExecuteInterceptor.cs
@@ -1,0 +1,10 @@
+﻿namespace EF.Interception.Tests
+{
+    public class PostExecuteInterceptor : Interceptor<IPostExecutedEntity>
+    {
+        public override void PostInsert(IContext<IPostExecutedEntity> context)
+        {
+            context.Entity.IsPostExecuted = true;
+        }
+    }
+}


### PR DESCRIPTION
Solution for #2.

I basically created the `BeforeState` property in the `EntityEntry` class so he can't be affected by the `Unchanged` state being applied by EF after calling the `SaveChanges()` method. The `BeforeState` property was then used as a criteria to filter only the implemented Post methods (`PostInsert`, `PostUpdate`, and `PostDelete`) as candidates for execution. 
Before and after implementing the change I ran a test for confirm that this solution was working fine and also to see if I didn't break anything and everything was good: my newly created test failed before the change and succeeded after and all the tests run fine.

I also had to install the `xunit.runner.console` package because the [xUnit.net VSIX is deprecated](http://xunit.github.io/docs/vsix-deprecated.html).

Just one more thing. While I was implementing this solution I faced a problem. Which Post method should be executed if the `Delete` method was executed using EF but the `PreDelete` interceptor method changed the `EntityState` to `Modified`? `PostUpdate` or `PostDelete`? I chosen the second option, but I would like to hear opinions about that.
